### PR TITLE
Fix listening port is not closed by sources

### DIFF
--- a/src/vban-udp-thread.c
+++ b/src/vban-udp-thread.c
@@ -59,6 +59,14 @@ static bool init_socket(vban_udp_t *dev)
 	return true;
 }
 
+static void finalize_socket(vban_udp_t *dev)
+{
+	if (dev->vban_socket != INVALID_SOCKET) {
+		closesocket(dev->vban_socket);
+		dev->vban_socket = INVALID_SOCKET;
+	}
+}
+
 static bool select_socket(vban_udp_t *dev)
 {
 	fd_set fd_read;
@@ -125,6 +133,8 @@ void *vban_udp_thread_main(void *data)
 		}
 		pthread_mutex_unlock(&dev->mutex);
 	}
+
+	finalize_socket(dev);
 
 	return NULL;
 }


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->
Fix a leakage of a socket, which is not closed.
Fix #2.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->
Tested on Fedora 36.

1. Open OBS Studio.
2. Create a VBAN source (set port to `6980`).
3. Switch to a new scene.
4. Check OBS is not listening the port 6980 with a command below.
 ```
netstat -unlp | grep obs
```
  - Prior to the fix, obs is still listening the port 6980.
  - With this fix, obs is not listening the port 6980.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
