### PR TITLE
src: Use deque instead of circlebuf

### DIFF
--- a/src/vban-output-internal.h
+++ b/src/vban-output-internal.h
@@ -1,7 +1,15 @@
 #pragma once
 
 #include <util/threading.h>
+#if LIBOBS_API_VER < MAKE_SEMANTIC_VERSION(30, 1, 0)
 #include <util/circlebuf.h>
+#define deque circlebuf
+#define deque_pop_front circlebuf_pop_front
+#define deque_push_back circlebuf_push_back
+#define deque_free circlebuf_free
+#else
+#include <util/deque.h>
+#endif
 #include "socket.h"
 
 struct vban_out_s
@@ -25,7 +33,7 @@ struct vban_out_s
 
 	struct resolve_thread_s *rt;
 
-	struct circlebuf buffer;
+	struct deque buffer;
 
 	uint64_t cnt_packets;
 	uint64_t cnt_frames;

--- a/src/vban-output-thread.c
+++ b/src/vban-output-thread.c
@@ -270,7 +270,7 @@ static void vban_out_loop(struct vban_out_s *v)
 		pthread_mutex_lock(&v->mutex);
 
 		if (v->buffer.size && !pkt.frames) {
-			circlebuf_pop_front(&v->buffer, &pkt, sizeof(pkt));
+			deque_pop_front(&v->buffer, &pkt, sizeof(pkt));
 		}
 
 		bool restart = bring_settings_unlocked(v, &t, &addr);

--- a/src/vban-output.c
+++ b/src/vban-output.c
@@ -89,7 +89,7 @@ static void vban_out_raw_audio(void *data, struct audio_data *frames)
 
 	pthread_mutex_lock(&v->mutex);
 
-	circlebuf_push_back(&v->buffer, &pkt, sizeof(pkt));
+	deque_push_back(&v->buffer, &pkt, sizeof(pkt));
 
 	os_event_signal(v->event);
 
@@ -210,7 +210,7 @@ static void vban_out_destroy(void *data)
 
 	while (v->buffer.size) {
 		struct audio_data pkt;
-		circlebuf_pop_front(&v->buffer, &pkt, sizeof(pkt));
+		deque_pop_front(&v->buffer, &pkt, sizeof(pkt));
 		for (size_t i = 0; i < MAX_AV_PLANES; i++)
 			bfree(pkt.data[i]);
 	}
@@ -220,7 +220,7 @@ static void vban_out_destroy(void *data)
 		v->rt = NULL;
 	}
 
-	circlebuf_free(&v->buffer);
+	deque_free(&v->buffer);
 	pthread_mutex_destroy(&v->mutex);
 	os_event_destroy(v->event);
 	bfree(v->stream_name);


### PR DESCRIPTION
### Description
<!--- Describe what was changed, why the change is required, what problem to be solved. -->

The `circlebuf` is deprecated and replaced by `deque`. This PR just replaces `circlebuf` with `deque`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- If something is not checked, please also describe it. -->

Compiled on Fedora 39 with the master of OBS Studio.

Might need to have a switch testing `LIBOBS_API_VER`.

<!-- If unsure, feel free to let them unchecked. -->
### General checklist
- [x] The commit is reviewed by yourself.
- [x] The code is tested.
- [x] Document is up to date or not necessary to be changed.
- [x] The commit is compatible with repository's license.
